### PR TITLE
MAC RTL implementation

### DIFF
--- a/rtl/core_wrap.sv
+++ b/rtl/core_wrap.sv
@@ -59,7 +59,7 @@ module core_wrap import croc_pkg::*; #() (
     .MHPMCounterNum     ( 0                   ),
     .MHPMCounterWidth   ( 40                  ),
     .RV32E              ( 0                   ),
-    .RV32M              ( cve2_pkg::RV32MNone ),
+    .RV32M              ( cve2_pkg::RV32MFast ),
     .RV32B              ( cve2_pkg::RV32BNone ),
     .DbgTriggerEn       ( 1'b1                ),
     .DbgHwBreakNum      ( 1                   ),

--- a/rtl/cve2/cve2_core.sv
+++ b/rtl/cve2/cve2_core.sv
@@ -155,8 +155,11 @@ module cve2_core import cve2_pkg::*; #(
   logic [31:0] rf_rdata_a;
   logic [4:0]  rf_raddr_b;
   logic [31:0] rf_rdata_b;
+  logic [4:0]  rf_raddr_c;
+  logic [31:0] rf_rdata_c;
   logic        rf_ren_a;
   logic        rf_ren_b;
+  logic        rf_ren_c;
   logic [4:0]  rf_waddr_wb;
   logic [31:0] rf_wdata_wb;
   // Writeback register write data that can be used on the forwarding path (doesn't factor in memory
@@ -186,6 +189,7 @@ module cve2_core import cve2_pkg::*; #(
   logic [1:0]  multdiv_signed_mode_ex;
   logic [31:0] multdiv_operand_a_ex;
   logic [31:0] multdiv_operand_b_ex;
+  logic [31:0] multdiv_operand_c_ex;
 
   // CSR control
   logic        csr_access;
@@ -409,6 +413,7 @@ module cve2_core import cve2_pkg::*; #(
     .multdiv_signed_mode_ex_o(multdiv_signed_mode_ex),
     .multdiv_operand_a_ex_o  (multdiv_operand_a_ex),
     .multdiv_operand_b_ex_o  (multdiv_operand_b_ex),
+    .multdiv_operand_c_ex_o  (multdiv_operand_c_ex),
 
     // CSR ID/EX
     .csr_access_o         (csr_access),
@@ -462,8 +467,11 @@ module cve2_core import cve2_pkg::*; #(
     .rf_rdata_a_i      (rf_rdata_a),
     .rf_raddr_b_o      (rf_raddr_b),
     .rf_rdata_b_i      (rf_rdata_b),
+    .rf_raddr_c_o      (rf_raddr_c),
+    .rf_rdata_c_i      (rf_rdata_c),
     .rf_ren_a_o        (rf_ren_a),
     .rf_ren_b_o        (rf_ren_b),
+    .rf_ren_c_o        (rf_ren_c),
     .rf_waddr_id_o     (rf_waddr_id),
     .rf_wdata_id_o     (rf_wdata_id),
     .rf_we_id_o        (rf_we_id),
@@ -506,6 +514,7 @@ module cve2_core import cve2_pkg::*; #(
     .multdiv_signed_mode_i(multdiv_signed_mode_ex),
     .multdiv_operand_a_i  (multdiv_operand_a_ex),
     .multdiv_operand_b_i  (multdiv_operand_b_ex),
+    .multdiv_operand_c_i  (multdiv_operand_c_ex),
 
     // Intermediate value register
     .imd_val_we_o(imd_val_we_ex),
@@ -653,6 +662,8 @@ module cve2_core import cve2_pkg::*; #(
     .rdata_a_o(rf_rdata_a),
     .raddr_b_i(rf_raddr_b),
     .rdata_b_o(rf_rdata_b),
+    .raddr_c_i(rf_raddr_c),
+    .rdata_c_o(rf_rdata_c),
     .waddr_a_i(rf_waddr_wb),
     .wdata_a_i(rf_wdata_wb),
     .we_a_i   (rf_we_wb)

--- a/rtl/cve2/cve2_decoder.sv
+++ b/rtl/cve2/cve2_decoder.sv
@@ -547,12 +547,12 @@ module cve2_decoder #(
               multdiv_signed_mode_o = 2'b00;
               illegal_insn          = (RV32M == RV32MNone) ? 1'b1 : 1'b0;
             end
-            {7'b000_0011, 3'b000}: begin // maccl
+            {7'b000_1001, 3'b000}: begin // maccl
               multdiv_operator_o    = MD_OP_MACCL;
               multdiv_signed_mode_o = 2'b11;
               illegal_insn          = (RV32M == RV32MNone) ? 1'b1 : 1'b0;
             end
-            {7'b000_0011, 3'b001}: begin // macch
+            {7'b000_1001, 3'b001}: begin // macch
               multdiv_operator_o    = MD_OP_MACCH;
               multdiv_signed_mode_o = 2'b11;
               illegal_insn          = (RV32M == RV32MNone) ? 1'b1 : 1'b0;
@@ -1111,7 +1111,14 @@ module cve2_decoder #(
               alu_operator_o = ALU_ADD;
               div_sel_o      = (RV32M == RV32MNone) ? 1'b0 : 1'b1;
             end
-
+            {7'b000_1001, 3'b000}: begin // maccl
+              alu_operator_o = ALU_ADD;
+              mult_sel_o     = (RV32M == RV32MNone) ? 1'b0 : 1'b1;
+            end
+            {7'b000_1001, 3'b001}: begin // macch
+              alu_operator_o = ALU_ADD;
+              mult_sel_o     = (RV32M == RV32MNone) ? 1'b0 : 1'b1;
+            end
             default: ;
           endcase
         end

--- a/rtl/cve2/cve2_decoder.sv
+++ b/rtl/cve2/cve2_decoder.sv
@@ -54,9 +54,11 @@ module cve2_decoder #(
   output logic                 rf_we_o,          // write enable for regfile
   output logic [4:0]           rf_raddr_a_o,
   output logic [4:0]           rf_raddr_b_o,
+  output logic [4:0]           rf_raddr_c_o,
   output logic [4:0]           rf_waddr_o,
   output logic                 rf_ren_a_o,          // Instruction reads from RF addr A
   output logic                 rf_ren_b_o,          // Instruction reads from RF addr B
+  output logic                 rf_ren_c_o,          // Instruction reads from RF addr C
 
   // ALU
   output cve2_pkg::alu_op_e    alu_operator_o,        // ALU operation selection
@@ -543,6 +545,16 @@ module cve2_decoder #(
             {7'b000_0001, 3'b111}: begin // remu
               multdiv_operator_o    = MD_OP_REM;
               multdiv_signed_mode_o = 2'b00;
+              illegal_insn          = (RV32M == RV32MNone) ? 1'b1 : 1'b0;
+            end
+            {7'b000_0011, 3'b000}: begin // maccl
+              multdiv_operator_o    = MD_OP_MACCL;
+              multdiv_signed_mode_o = 2'b11;
+              illegal_insn          = (RV32M == RV32MNone) ? 1'b1 : 1'b0;
+            end
+            {7'b000_0011, 3'b001}: begin // macch
+              multdiv_operator_o    = MD_OP_MACCH;
+              multdiv_signed_mode_o = 2'b11;
               illegal_insn          = (RV32M == RV32MNone) ? 1'b1 : 1'b0;
             end
             default: begin

--- a/rtl/cve2/cve2_decoder.sv
+++ b/rtl/cve2/cve2_decoder.sv
@@ -165,6 +165,7 @@ module cve2_decoder #(
   assign instr_rs3 = instr[31:27];
   assign rf_raddr_a_o = (use_rs3_q & ~instr_first_cycle_i) ? instr_rs3 : instr_rs1; // rs3 / rs1
   assign rf_raddr_b_o = instr_rs2; // rs2
+  assign rf_raddr_c_o = instr_rd;
 
   // destination register
   assign instr_rd = instr[11:7];

--- a/rtl/cve2/cve2_ex_block.sv
+++ b/rtl/cve2/cve2_ex_block.sv
@@ -30,6 +30,7 @@ module cve2_ex_block #(
   input  logic  [1:0]           multdiv_signed_mode_i,
   input  logic [31:0]           multdiv_operand_a_i,
   input  logic [31:0]           multdiv_operand_b_i,
+  input  logic [31:0]           multdiv_operand_c_i,
 
   // intermediate val reg
   output logic [1:0]            imd_val_we_o,
@@ -154,6 +155,7 @@ module cve2_ex_block #(
       .signed_mode_i     (multdiv_signed_mode_i),
       .op_a_i            (multdiv_operand_a_i),
       .op_b_i            (multdiv_operand_b_i),
+      .op_c_i            (multdiv_operand_c_i),
       .alu_operand_a_o   (multdiv_alu_operand_a),
       .alu_operand_b_o   (multdiv_alu_operand_b),
       .alu_adder_ext_i   (alu_adder_result_ext),

--- a/rtl/cve2/cve2_id_stage.sv
+++ b/rtl/cve2/cve2_id_stage.sv
@@ -76,6 +76,7 @@ module cve2_id_stage #(
   output logic  [1:0]               multdiv_signed_mode_ex_o,
   output logic [31:0]               multdiv_operand_a_ex_o,
   output logic [31:0]               multdiv_operand_b_ex_o,
+  output logic [31:0]               multdiv_operand_c_ex_o,
 
   // CSR
   output logic                      csr_access_o,
@@ -130,8 +131,11 @@ module cve2_id_stage #(
   input  logic [31:0]               rf_rdata_a_i,
   output logic [4:0]                rf_raddr_b_o,
   input  logic [31:0]               rf_rdata_b_i,
+  output logic [4:0]                rf_raddr_c_o,
+  input  logic [31:0]               rf_rdata_c_i,
   output logic                      rf_ren_a_o,
   output logic                      rf_ren_b_o,
+  output logic                      rf_ren_c_o,
 
   // Register file write (via writeback)
   output logic [4:0]                rf_waddr_id_o,
@@ -197,18 +201,21 @@ module cve2_id_stage #(
 
   rf_wd_sel_e  rf_wdata_sel;
   logic        rf_we_dec, rf_we_raw;
-  logic        rf_ren_a, rf_ren_b;
-  logic        rf_ren_a_dec, rf_ren_b_dec;
+  logic        rf_ren_a, rf_ren_b, rf_ren_c;
+  logic        rf_ren_a_dec, rf_ren_b_dec, rf_ren_c_dec;
 
   // Read enables should only be asserted for valid and legal instructions
   assign rf_ren_a = instr_valid_i & ~instr_fetch_err_i & ~illegal_insn_o & rf_ren_a_dec;
   assign rf_ren_b = instr_valid_i & ~instr_fetch_err_i & ~illegal_insn_o & rf_ren_b_dec;
+  assign rf_ren_c = instr_valid_i & ~instr_fetch_err_i & ~illegal_insn_o & rf_ren_c_dec;
 
   assign rf_ren_a_o = rf_ren_a;
   assign rf_ren_b_o = rf_ren_b;
+  assign rf_ren_c_o = rf_ren_c;
 
   logic [31:0] rf_rdata_a_fwd;
   logic [31:0] rf_rdata_b_fwd;
+  logic [31:0] rf_rdata_c_fwd;
 
   // ALU Control
   alu_op_e     alu_operator;
@@ -373,9 +380,11 @@ module cve2_id_stage #(
 
     .rf_raddr_a_o(rf_raddr_a_o),
     .rf_raddr_b_o(rf_raddr_b_o),
+    .rf_raddr_c_o(rf_raddr_c_o),
     .rf_waddr_o  (rf_waddr_id_o),
     .rf_ren_a_o  (rf_ren_a_dec),
     .rf_ren_b_o  (rf_ren_b_dec),
+    .rf_ren_c_o  (rf_ren_c_dec),
 
     // ALU
     .alu_operator_o    (alu_operator),
@@ -552,6 +561,7 @@ module cve2_id_stage #(
   assign multdiv_signed_mode_ex_o    = multdiv_signed_mode;
   assign multdiv_operand_a_ex_o      = rf_rdata_a_fwd;
   assign multdiv_operand_b_ex_o      = rf_rdata_b_fwd;
+  assign multdiv_operand_c_ex_o      = rf_rdata_c_fwd;
 
   ////////////////////////
   // Branch set control //
@@ -741,6 +751,7 @@ module cve2_id_stage #(
     // register file
     assign rf_rdata_a_fwd = rf_rdata_a_i;
     assign rf_rdata_b_fwd = rf_rdata_b_i;
+    assign rf_rdata_c_fwd = rf_rdata_c_i;
 
     // Unused Writeback stage only IO & wiring
     // Assign inputs and internal wiring to unused signals to satisfy lint checks

--- a/rtl/cve2/cve2_pkg.sv
+++ b/rtl/cve2/cve2_pkg.sv
@@ -177,12 +177,14 @@ package cve2_pkg;
     ALU_CRC32C_W
   } alu_op_e;
 
-  typedef enum logic [1:0] {
+  typedef enum logic [2:0] {
     // Multiplier/divider
     MD_OP_MULL,
     MD_OP_MULH,
     MD_OP_DIV,
-    MD_OP_REM
+    MD_OP_REM,
+    MD_OP_MACCL,
+    MD_OP_MACCH
   } md_op_e;
 
 

--- a/rtl/cve2/cve2_register_file_ff.sv
+++ b/rtl/cve2/cve2_register_file_ff.sv
@@ -29,6 +29,9 @@ module cve2_register_file_ff #(
   input  logic [4:0]           raddr_b_i,
   output logic [DataWidth-1:0] rdata_b_o,
 
+  //Read port R3
+  input  logic [4:0]           raddr_c_i,
+  output logic [DataWidth-1:0] rdata_c_o,
 
   // Write port W1
   input  logic [4:0]           waddr_a_i,
@@ -68,6 +71,8 @@ module cve2_register_file_ff #(
 
   assign rdata_a_o = rf_reg[raddr_a_i];
   assign rdata_b_o = rf_reg[raddr_b_i];
+  assign rdata_c_o = rf_reg[raddr_c_i];
+
 
   // Signal not used in FF register file
   logic unused_test_en;

--- a/sw/lib/inc/mac.h
+++ b/sw/lib/inc/mac.h
@@ -4,7 +4,7 @@
 // OP 0110011
 #define MAC_OPCODE 0x33
 #define MAC_FUNCT3 0x0
-#define MAC_FUNCT7 0x3
+#define MAC_FUNCT7 0x9
 // R type for gnu assembler: opcode, func3, func7, rd, rs1, rs2
 #define MAC(a, b, c)                                                           \
   asm volatile(".insn r %1, %2, %3, %0, %4, %5"                                \

--- a/sw/lib/inc/mac.h
+++ b/sw/lib/inc/mac.h
@@ -8,6 +8,6 @@
 // R type for gnu assembler: opcode, func3, func7, rd, rs1, rs2
 #define MAC(a, b, c)                                                           \
   asm volatile(".insn r %1, %2, %3, %0, %4, %5"                                \
-               : "=r"(a)                                                       \
+               : "+&r"(a)                                                      \
                : "i"(MAC_OPCODE), "i"(MAC_FUNCT3), "i"(MAC_FUNCT7), "r"(b),    \
                  "r"(c))

--- a/sw/lib/inc/mac.h
+++ b/sw/lib/inc/mac.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <stdint.h>
 
-// custom-0 0001011
-#define MAC_OPCODE 0xB
+// OP 0110011
+#define MAC_OPCODE 0x33
 #define MAC_FUNCT3 0x0
-#define MAC_FUNCT7 0x0
+#define MAC_FUNCT7 0x3
 // R type for gnu assembler: opcode, func3, func7, rd, rs1, rs2
 #define MAC(a, b, c)                                                           \
   asm volatile(".insn r %1, %2, %3, %0, %4, %5"                                \


### PR DESCRIPTION
I have fixed some issues in the RTL implementation and the very basic MAC test works now.
I have also tried it with some large positive and some negative numbers and it works fine.
I did not test the MACCH instruction for the moment, I propose we mainly focus on 32 bit anyway, since if we get the 64 bit result in two registers it is a bit of a pain in software to use that 64 bit result in further MAC instructions (definitely possible but I think we can do fine with 32 bit for now).